### PR TITLE
Generate in batches and bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 .DS_Store
+output

--- a/generate_documents.py
+++ b/generate_documents.py
@@ -16,6 +16,7 @@ import names
 import random
 import json
 import argparse
+import shutil
 
 
 def get_parser():
@@ -177,11 +178,13 @@ def createDocument(text, title, folder, class_names, doc_no):
 if __name__ == "__main__":
     args = get_parser()
     batch = args.batch
-    if os.path.exists("output") == False:
-        try:
-            os.mkdir("./output")
-        except OSError:
-            print("Creation of the directory failed")
+    if os.path.exists("output") == True:
+        shutil.rmtree("output")
+        print("Previous output deleted")
+    try:
+        os.mkdir("./output")
+    except OSError:
+        print("Creation of the directory failed")
 
     print("Successfully created the directory")
     for i in range(batch):

--- a/generate_documents.py
+++ b/generate_documents.py
@@ -19,7 +19,7 @@ import argparse
 
 
 def GenerateBatch(args, batch):
-    amt = args.amount
+    amt = args.number
     wiki_title = args.title
     num_sentences = args.sentences
 
@@ -131,9 +131,9 @@ if __name__ == "__main__":
         default="Machine Learning",
     )
     parser.add_argument(
-        "-a",
-        "--amount",
-        help="The amount of documents to generate in a batch",
+        "-n",
+        "--number",
+        help="The number of documents to generate in a batch",
         default=10,
         type=int,
     )

--- a/generate_documents.py
+++ b/generate_documents.py
@@ -18,47 +18,85 @@ import json
 import argparse
 
 
-def createDocument(text, title, folder, class_names):
+def createDocument(text, title, folder, class_names, doc_no):
     document = Document()
     # Name
     obj_styles = document.styles
-    obj_charstyle = obj_styles.add_style('NameStyle', WD_STYLE_TYPE.CHARACTER)
+    obj_charstyle = obj_styles.add_style("NameStyle", WD_STYLE_TYPE.CHARACTER)
     obj_font = obj_charstyle.font
     obj_font.size = Pt(12)
-    obj_font.name = 'Times New Roman'
+    obj_font.name = "Times New Roman"
     name = document.add_paragraph()
     className = document.add_paragraph()
-    name.add_run(names.get_full_name(), style='NameStyle')
-    className.add_run(random.choice(class_names), style='NameStyle')
+    name.add_run(names.get_full_name(), style="NameStyle")
+    className.add_run(random.choice(class_names), style="NameStyle")
     # Heading
     obj_styles = document.styles
-    obj_charstyle = obj_styles.add_style(
-        'CommentsStyle', WD_STYLE_TYPE.CHARACTER)
+    obj_charstyle = obj_styles.add_style("CommentsStyle", WD_STYLE_TYPE.CHARACTER)
     obj_font = obj_charstyle.font
     obj_font.size = Pt(16)
-    obj_font.name = 'Times New Roman'
+    obj_font.name = "Times New Roman"
     paragraph = document.add_paragraph()
-    paragraph.add_run(title, style='CommentsStyle').bold = True
+    paragraph.add_run(title, style="CommentsStyle").bold = True
     paragraph.alignment = WD_ALIGN_PARAGRAPH.CENTER
     # Content
     paragraph = document.add_paragraph(text)
 
-    document.save("./" + folder + "/" + "".join(i for i in title.strip() if i not in "\/:*?<>|") + ".docx")
+    document.save(
+        "./"
+        + folder
+        + "/"
+        + f"{doc_no} "
+        + "".join(i for i in title.strip() if i not in "\/:*?<>|")
+        + ".docx"
+    )
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
     # add arguments for number of documents to generate and the page to use
-    parser.add_argument("-t", "--title", help="The wikipedia page title to use for generating documents",
-                        type=str, default="Machine Learning")
     parser.add_argument(
-        "-a", "--amount", help="The amount of documents to generate", default=10, type=int)
+        "-t",
+        "--title",
+        help="The wikipedia page title to use for generating documents",
+        type=str,
+        default="Machine Learning",
+    )
+    parser.add_argument(
+        "-a",
+        "--amount",
+        help="The amount of documents to generate",
+        default=10,
+        type=int,
+    )
     # add argument for the class names
-    parser.add_argument("-c", "--class_names", help="The class names to use for generating documents",
-                        type=list, default=["CS 1", "CS 2", "CS 3", "CS 4", "CS 5", "CS 6", "CS 7", "CS 8", "CS 9", "CS 10"])
     parser.add_argument(
-        "-s", "--sentences", help="The number of sentences to use for each chunk", default=25, type=int)
+        "-c",
+        "--class_names",
+        help="The class names to use for generating documents",
+        type=list,
+        default=[
+            "CS 1",
+            "CS 2",
+            "CS 3",
+            "CS 4",
+            "CS 5",
+            "CS 6",
+            "CS 7",
+            "CS 8",
+            "CS 9",
+            "CS 10",
+        ],
+    )
+    parser.add_argument(
+        "-s",
+        "--sentences",
+        help="The number of sentences to use for each chunk",
+        default=25,
+        type=int,
+    )
 
     args = parser.parse_args()
     amt = args.amount
@@ -86,7 +124,7 @@ if __name__ == "__main__":
         curstr = ""
         print("Paraphrasing Chunk " + str(len(chunked)))
         for x in page_content:
-            if (len(chunked) >= amt):
+            if len(chunked) >= amt:
                 break
             if count == num_sentences:
                 count = 0
@@ -97,24 +135,30 @@ if __name__ == "__main__":
             count += 1
         chunked.append(curstr)
         count = 0
-        if os.path.exists(page.title) == False:
+        folder = page.title
+        if os.path.exists(folder) == False:
             try:
-                os.mkdir("./" + page.title)
+                os.mkdir("./" + folder)
             except OSError:
                 print("Creation of the directory failed")
 
         print("Successfully created the directory")
 
         # Write chunks to word docs
-        for x in chunked:
+        for i, x in enumerate(chunked):
             print("Writing chunk " + str(count) + " to word doc")
             title = " ".join(nltk.word_tokenize(x)[0:3])
-            createDocument(x, title, page.title, class_names)
+            createDocument(x, title, folder, class_names, doc_no=i + 1)
             count += 1
             generated += 1
-            if generated > amt:
+            if generated >= amt:
                 break
             else:
-                print("Made " + str(generated) + " docs with this article so far. Need " +
-                      str(amt-generated) + " docs more.")
+                print(
+                    "Made "
+                    + str(generated)
+                    + " docs with this article so far. Need "
+                    + str(amt - generated)
+                    + " docs more."
+                )
     print("Successfully generated " + str(amt) + " documents. Thank you!")

--- a/generate_documents.py
+++ b/generate_documents.py
@@ -20,14 +20,14 @@ import argparse
 
 def GenerateBatch(args, batch):
     amt = args.amount
-    page = args.title
+    wiki_title = args.title
     num_sentences = args.sentences
 
     class_names = args.class_names
     generated = 0
     while generated < amt:
         try:
-            page = wikipedia.page(page, auto_suggest=False)
+            page = wikipedia.page(wiki_title, auto_suggest=False)
             print("The url for page is " + page.url)
         except Exception as e:
             print("There was an error getting the page. Please try again.")
@@ -65,10 +65,10 @@ def GenerateBatch(args, batch):
         print("Successfully created the directory")
 
         # Write chunks to word docs
-        for i, x in enumerate(chunked):
+        for x in chunked:
             print("Writing chunk " + str(count) + " to word doc")
             title = " ".join(nltk.word_tokenize(x)[0:3])
-            createDocument(x, title, folder, class_names, doc_no=i + 1)
+            createDocument(x, title, folder, class_names, doc_no=generated + 1)
             count += 1
             generated += 1
             if generated >= amt:

--- a/generate_documents.py
+++ b/generate_documents.py
@@ -18,6 +18,62 @@ import json
 import argparse
 
 
+def get_parser():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    # add arguments for number of documents to generate and the page to use
+    parser.add_argument(
+        "-t",
+        "--title",
+        help="The wikipedia page title to use for generating documents",
+        type=str,
+        default="Machine Learning",
+    )
+    parser.add_argument(
+        "-n",
+        "--number",
+        help="The number of documents to generate in a batch",
+        default=10,
+        type=int,
+    )
+    parser.add_argument(
+        "-b",
+        "--batch",
+        help="The number of batches to generate",
+        default=1,
+        type=int,
+    )
+    # add argument for the class names
+    parser.add_argument(
+        "-c",
+        "--class_names",
+        help="The class names to use for generating documents",
+        type=list,
+        default=[
+            "CS 1",
+            "CS 2",
+            "CS 3",
+            "CS 4",
+            "CS 5",
+            "CS 6",
+            "CS 7",
+            "CS 8",
+            "CS 9",
+            "CS 10",
+        ],
+    )
+    parser.add_argument(
+        "-s",
+        "--sentences",
+        help="The number of sentences to use for each chunk",
+        default=25,
+        type=int,
+    )
+
+    return parser.parse_args()
+
+
 def GenerateBatch(args, batch):
     amt = args.number
     wiki_title = args.title
@@ -119,59 +175,7 @@ def createDocument(text, title, folder, class_names, doc_no):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter
-    )
-    # add arguments for number of documents to generate and the page to use
-    parser.add_argument(
-        "-t",
-        "--title",
-        help="The wikipedia page title to use for generating documents",
-        type=str,
-        default="Machine Learning",
-    )
-    parser.add_argument(
-        "-n",
-        "--number",
-        help="The number of documents to generate in a batch",
-        default=10,
-        type=int,
-    )
-    parser.add_argument(
-        "-b",
-        "--batch",
-        help="The number of batches to generate",
-        default=1,
-        type=int,
-    )
-    # add argument for the class names
-    parser.add_argument(
-        "-c",
-        "--class_names",
-        help="The class names to use for generating documents",
-        type=list,
-        default=[
-            "CS 1",
-            "CS 2",
-            "CS 3",
-            "CS 4",
-            "CS 5",
-            "CS 6",
-            "CS 7",
-            "CS 8",
-            "CS 9",
-            "CS 10",
-        ],
-    )
-    parser.add_argument(
-        "-s",
-        "--sentences",
-        help="The number of sentences to use for each chunk",
-        default=25,
-        type=int,
-    )
-
-    args = parser.parse_args()
+    args = get_parser()
     batch = args.batch
     if os.path.exists("output") == False:
         try:


### PR DESCRIPTION
Changes:
- All generated documents are stored in the ./output directory for better organization.
- Documents from the previous run are deleted automatically.
- Batches and document names are numbered.
- Added -b argument which specifies the number of batches to generate. Each batch is stored in a separate directory. This is particularly useful for acquiring many Coursehero unlocks  since each Coursehero account accepts at most 40 uploads in a short period of time (which gives 20 unlocks per account).
- Renamed the -a argument to -n for clarity.
- Fixed a bug causing KeyError: 'fullurl'.
- Some code refactoring.